### PR TITLE
widget: allow slight floating point variation in tests

### DIFF
--- a/widget/progressbarinfinite_test.go
+++ b/widget/progressbarinfinite_test.go
@@ -69,7 +69,7 @@ func TestInfiniteProgressRenderer_Layout(t *testing.T) {
 
 	render.updateBar(0.0)
 	// start at the smallest size
-	assert.Equal(t, width*minProgressBarInfiniteWidthRatio, render.bar.Size().Width)
+	assert.InEpsilon(t, width*minProgressBarInfiniteWidthRatio, render.bar.Size().Width, 0.0001)
 
 	// make sure the inner progress bar grows in size
 	// call updateBar() enough times to grow the inner bar


### PR DESCRIPTION
This test was failing locally. Exact comparison of floating point values is fraught.

### Checklist:

- [x] Tests included.
- [ ] Lint and formatter run with no errors.
- [ ] Tests all pass.

